### PR TITLE
Allow the user to specify the interface name to bind

### DIFF
--- a/config.c
+++ b/config.c
@@ -814,6 +814,7 @@ parse_error:
 struct interface *config_create_interface(char *name, struct config *cfg)
 {
 	struct interface *iface;
+	char *ptr;
 
 	/* only create each interface once (by name) */
 	STAILQ_FOREACH(iface, &cfg->interfaces, list) {
@@ -828,6 +829,13 @@ struct interface *config_create_interface(char *name, struct config *cfg)
 	}
 
 	strncpy(iface->name, name, MAX_IFNAME_SIZE);
+	if ((ptr = strchr(iface->name, ':'))) {
+		*ptr = 0;
+		strncpy(iface->bind, ptr + 1, MAX_IFNAME_SIZE);
+	} else {
+		strncpy(iface->bind, name, MAX_IFNAME_SIZE);
+	}
+
 	STAILQ_INSERT_TAIL(&cfg->interfaces, iface, list);
 	cfg->n_interfaces++;
 

--- a/config.h
+++ b/config.h
@@ -42,6 +42,7 @@ struct interface {
 	STAILQ_ENTRY(interface) list;
 	char name[MAX_IFNAME_SIZE + 1];
 	char ts_label[MAX_IFNAME_SIZE + 1];
+	char bind[MAX_IFNAME_SIZE + 1];
 	struct sk_ts_info ts_info;
 };
 

--- a/raw.c
+++ b/raw.c
@@ -225,11 +225,11 @@ static int raw_open(struct transport *t, struct interface *iface,
 	if (sk_interface_macaddr(name, &raw->src_addr))
 		goto no_mac;
 
-	efd = open_socket(name, 1, ptp_dst_mac, p2p_dst_mac);
+	efd = open_socket(iface->bind, 1, ptp_dst_mac, p2p_dst_mac);
 	if (efd < 0)
 		goto no_event;
 
-	gfd = open_socket(name, 0, ptp_dst_mac, p2p_dst_mac);
+	gfd = open_socket(iface->bind, 0, ptp_dst_mac, p2p_dst_mac);
 	if (gfd < 0)
 		goto no_general;
 

--- a/udp.c
+++ b/udp.c
@@ -171,11 +171,11 @@ static int udp_open(struct transport *t, struct interface *iface,
 	if (!inet_aton(PTP_PDELAY_MCAST_IPADDR, &mcast_addr[MC_PDELAY]))
 		return -1;
 
-	efd = open_socket(name, mcast_addr, EVENT_PORT, ttl);
+	efd = open_socket(iface->bind, mcast_addr, EVENT_PORT, ttl);
 	if (efd < 0)
 		goto no_event;
 
-	gfd = open_socket(name, mcast_addr, GENERAL_PORT, ttl);
+	gfd = open_socket(iface->bind, mcast_addr, GENERAL_PORT, ttl);
 	if (gfd < 0)
 		goto no_general;
 

--- a/udp6.c
+++ b/udp6.c
@@ -182,11 +182,11 @@ static int udp6_open(struct transport *t, struct interface *iface,
 	if (1 != inet_pton(AF_INET6, PTP_PDELAY_MCAST_IP6ADDR, &mc6_addr[MC_PDELAY]))
 		return -1;
 
-	efd = open_socket_ipv6(name, mc6_addr, EVENT_PORT, &udp6->index, hop_limit);
+	efd = open_socket_ipv6(iface->bind, mc6_addr, EVENT_PORT, &udp6->index, hop_limit);
 	if (efd < 0)
 		goto no_event;
 
-	gfd = open_socket_ipv6(name, mc6_addr, GENERAL_PORT, &udp6->index, hop_limit);
+	gfd = open_socket_ipv6(iface->bind, mc6_addr, GENERAL_PORT, &udp6->index, hop_limit);
 	if (gfd < 0)
 		goto no_general;
 


### PR DESCRIPTION
This could be useful in case of bridged ethernet ports.

Example: ptp4l -i eth0:br0

This command will use hardware capabilities of eth0 and would configure
the IP stack to be bound to the bridge.