### PR TITLE
Allow multiple ptp4l instances to run by setting SO_REUSEPORT

### DIFF
--- a/udp.c
+++ b/udp.c
@@ -114,6 +114,10 @@ static int open_socket(const char *name, struct in_addr mc_addr[2], short port,
 		pr_err("setsockopt SO_REUSEADDR failed: %m");
 		goto no_option;
 	}
+	if (setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &on, sizeof(on))) {
+		pr_err("setsockopt SO_REUSEPORT failed: %m");
+		goto no_option;
+	}
 	if (bind(fd, (struct sockaddr *) &addr, sizeof(addr))) {
 		pr_err("bind failed: %m");
 		goto no_option;

--- a/udp6.c
+++ b/udp6.c
@@ -127,6 +127,10 @@ static int open_socket_ipv6(const char *name, struct in6_addr mc_addr[2], short 
 		pr_err("setsockopt SO_REUSEADDR failed: %m");
 		goto no_option;
 	}
+	if (setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &on, sizeof(on))) {
+		pr_err("setsockopt SO_REUSEPORT failed: %m");
+		goto no_option;
+	}
 	if (bind(fd, (struct sockaddr *) &addr, sizeof(addr))) {
 		pr_err("bind failed: %m");
 		goto no_option;


### PR DESCRIPTION
For the scalability and reliability reasons we need to run multiple instances of ptp4l on the server.
This pull requests sets enabled SO_REUSEPORT which allows several ptp4l instances to bind to port 319/320 and serve much more unicast clients.