### PR TITLE
Make portNumber configurable

### DIFF
--- a/clock.c
+++ b/clock.c
@@ -1111,7 +1111,6 @@ struct clock *clock_create(enum clock_type type, struct config *config,
 	c->kernel_leap = config_get_int(config, NULL, "kernel_leap");
 	c->utc_offset = config_get_int(config, NULL, "utc_offset");
 	c->time_source = config_get_int(config, NULL, "timeSource");
-	c->step_window = config_get_int(config, NULL, "step_window");
 
 	if (c->free_running) {
 		c->clkid = CLOCK_INVALID;
@@ -1768,8 +1767,9 @@ int clock_switch_phc(struct clock *c, int phc_index)
 	return 0;
 }
 
-static void clock_step_window(struct clock *c)
+static void clock_step_window(struct clock *c, struct port *p)
 {
+	c->step_window = port_step_window(p);
 	if (!c->step_window) {
 		return;
 	}
@@ -1787,7 +1787,7 @@ static void clock_synchronize_locked(struct clock *c, double adj)
 	}
 }
 
-enum servo_state clock_synchronize(struct clock *c, tmv_t ingress, tmv_t origin)
+enum servo_state clock_synchronize(struct clock *c, struct port *p, tmv_t ingress, tmv_t origin)
 {
 	enum servo_state state = SERVO_UNLOCKED;
 	double adj, weight;
@@ -1845,7 +1845,7 @@ enum servo_state clock_synchronize(struct clock *c, tmv_t ingress, tmv_t origin)
 					-tmv_to_nanoseconds(c->master_offset));
 		}
 		tsproc_reset(c->tsproc, 0);
-		clock_step_window(c);
+		clock_step_window(c, p);
 		break;
 	case SERVO_LOCKED:
 		clock_synchronize_locked(c, adj);

--- a/clock.c
+++ b/clock.c
@@ -826,12 +826,22 @@ static int clock_add_port(struct clock *c, const char *phc_device,
 			  struct interface *iface)
 {
 	struct port *p, *piter, *lastp = NULL;
+	int port_number = config_get_int(c->config, interface_name(iface), "portNumber");
 
 	if (clock_resize_pollfd(c, c->nports + 2)) {
 		return -1;
 	}
+
+	if (port_number) {
+		c->last_port_number = (c->last_port_number > port_number ?
+		                       c->last_port_number : port_number) + 1;
+	} else {
+		port_number = ++c->last_port_number;
+	}
+
 	p = port_open(phc_device, phc_index, timestamping,
-		      ++c->last_port_number, iface, c);
+		      port_number, iface, c);
+
 	if (!p) {
 		/* No need to shrink pollfd */
 		return -1;

--- a/clock.h
+++ b/clock.h
@@ -314,6 +314,7 @@ int clock_switch_phc(struct clock *c, int phc_index);
 /**
  * Provide a data point to synchronize the clock.
  * @param c            The clock instance to synchronize.
+ * @param p            The port instance that asks for synchronize.
  * @param ingress      The ingress time stamp on the sync message.
  * @param origin       The reported transmission time of the sync message,
                        including any corrections.
@@ -322,8 +323,8 @@ int clock_switch_phc(struct clock *c, int phc_index);
  *                     Pass zero in the case of one step operation.
  * @return             The state of the clock's servo.
  */
-enum servo_state clock_synchronize(struct clock *c, tmv_t ingress,
-				   tmv_t origin);
+enum servo_state clock_synchronize(struct clock *c, struct port *p,
+                                   tmv_t ingress, tmv_t origin);
 
 /**
  * Inform a slaved clock about the master's sync interval.

--- a/config.c
+++ b/config.c
@@ -305,7 +305,7 @@ struct config_item config_tab[] = {
 	GLOB_ITEM_INT("slaveOnly", 0, 0, 1), /*deprecated*/
 	GLOB_ITEM_INT("socket_priority", 0, 0, 15),
 	GLOB_ITEM_DBL("step_threshold", 0.0, 0.0, DBL_MAX),
-	GLOB_ITEM_INT("step_window", 0, 0, INT_MAX),
+	PORT_ITEM_INT("step_window", 0, 0, INT_MAX),
 	GLOB_ITEM_INT("summary_interval", 0, INT_MIN, INT_MAX),
 	PORT_ITEM_INT("syncReceiptTimeout", 0, 0, UINT8_MAX),
 	GLOB_ITEM_INT("tc_spanning_tree", 0, 0, 1),

--- a/config.c
+++ b/config.c
@@ -291,6 +291,7 @@ struct config_item config_tab[] = {
 	GLOB_ITEM_DBL("pi_proportional_exponent", -0.3, -DBL_MAX, DBL_MAX),
 	GLOB_ITEM_DBL("pi_proportional_norm_max", 0.7, DBL_MIN, 1.0),
 	GLOB_ITEM_DBL("pi_proportional_scale", 0.0, 0.0, DBL_MAX),
+	GLOB_ITEM_INT("portNumber", 0, 0, UINT16_MAX),
 	GLOB_ITEM_INT("priority1", 128, 0, UINT8_MAX),
 	GLOB_ITEM_INT("priority2", 128, 0, UINT8_MAX),
 	GLOB_ITEM_STR("productDescription", ";;"),

--- a/port.c
+++ b/port.c
@@ -189,6 +189,11 @@ int port_fault_fd(struct port *port)
 	return port->fault_fd;
 }
 
+int port_step_window(struct port *p)
+{
+	return p->step_window;
+}
+
 struct fdarray *port_fda(struct port *port)
 {
 	return &port->fda;
@@ -1194,7 +1199,7 @@ static void port_synchronize(struct port *p,
 	}
 
 	last_state = clock_servo_state(p->clock);
-	state = clock_synchronize(p->clock, t2, t1c);
+	state = clock_synchronize(p->clock, p, t2, t1c);
 	switch (state) {
 	case SERVO_UNLOCKED:
 		port_dispatch(p, EV_SYNCHRONIZATION_FAULT, 0);
@@ -3134,6 +3139,7 @@ struct port *port_open(const char *phc_device,
 	p->delayMechanism = config_get_int(cfg, p->name, "delay_mechanism");
 	p->versionNumber = PTP_VERSION;
 	p->slave_event_monitor = clock_slave_monitor(clock);
+	p->step_window = config_get_int(cfg, interface_name(interface), "step_window");
 
 	if (!port_is_uds(p) && unicast_client_initialize(p)) {
 		goto err_transport;

--- a/port.h
+++ b/port.h
@@ -253,6 +253,13 @@ struct fdarray *port_fda(struct port *port);
 int port_fault_fd(struct port *port);
 
 /**
+ * Return the step_window starting counter
+ * @param port	A port instance.
+ * @return	The step_window value.
+ */
+int port_step_window(struct port *p);
+
+/**
  * Utility function for setting or resetting a file descriptor timer.
  *
  * This function sets the timer 'fd' to the value M(2^N), where M is

--- a/port_private.h
+++ b/port_private.h
@@ -155,6 +155,7 @@ struct port {
 	int inhibit_multicast_service;
 	/* slave event monitoring */
 	struct monitor *slave_event_monitor;
+	int step_window;
 };
 
 #define portnum(p) (p->portIdentity.portNumber)


### PR DESCRIPTION
In my configuration manager the portNumber is deducted by model and not depending from port configuration order.
I hope that this change can be useful.