### PR TITLE
fix dynamic string probable double free bug.

### DIFF
--- a/config.c
+++ b/config.c
@@ -413,8 +413,10 @@ static struct config_item *config_item_alloc(struct config *cfg,
 static void config_item_free(void *ptr)
 {
 	struct config_item *ci = ptr;
-	if (ci->type == CFG_TYPE_STRING && ci->flags & CFG_ITEM_DYNSTR)
+	if (ci->type == CFG_TYPE_STRING && ci->flags & CFG_ITEM_DYNSTR){
 		free(ci->val.s);
+		ci->flags ^= CFG_ITEM_DYNSTR;	
+	}
 	if (ci->flags & CFG_ITEM_STATIC)
 		return;
 	free(ci);


### PR DESCRIPTION
If user tries to run config_create() multiple times using the same .cfg file, free dynstr without clear the flag will result double free bug. Which is freed in config.c parse_item().