### PR TITLE
Allow one to set utc_timescale via config.

### DIFF
--- a/clock.c
+++ b/clock.c
@@ -1312,6 +1312,7 @@ struct clock *clock_create(enum clock_type type, struct config *config,
 		max_adj = sysclk_max_freq();
 		sysclk_set_leap(0);
 	}
+	c->utc_timescale = config_get_int(config, NULL, "utc_timescale");
 	c->utc_offset_set = 0;
 	c->leap_set = 0;
 	c->time_flags = c->utc_timescale ? 0 : PTP_TIMESCALE;

--- a/config.c
+++ b/config.c
@@ -362,6 +362,7 @@ struct config_item config_tab[] = {
 	GLOB_ITEM_INT("use_syslog", 1, 0, 1),
 	GLOB_ITEM_STR("userDescription", ""),
 	GLOB_ITEM_INT("utc_offset", CURRENT_UTC_OFFSET, 0, INT_MAX),
+	GLOB_ITEM_INT("utc_timescale", 0, 0, 1),
 	GLOB_ITEM_INT("verbose", 0, 0, 1),
 	GLOB_ITEM_INT("write_phase_mode", 0, 0, 1),
 };

--- a/ptp4l.8
+++ b/ptp4l.8
@@ -970,6 +970,11 @@ name;location and contain at most 128 utf8 symbols. The default is an
 empty string.
 
 .TP
+.B utc_timescale
+By default TAI timescale is used in case of HW timestamping and UTC for
+SW timestamps. One can override this with the setting. Allowed values 0, 1.
+
+.TP
 .B utc_offset
 The current offset between TAI and UTC.
 The default is 37.


### PR DESCRIPTION
There are configs, when you want UTC timescale in PTP domain for
most dumb devices, but there are some that follow ptpTimescale
parameter from master, but not the currentUtcOffset.