### PR TITLE
ts2phc: Enable CLOCK_REALTIME Synchronization with NMEA Sentences

### DIFF
--- a/ts2phc.c
+++ b/ts2phc.c
@@ -480,6 +480,16 @@ static void ts2phc_synchronize_clocks(struct ts2phc_private *priv, int autocfg)
 		double adj;
 		tmv_t ts;
 
+		if (c->clkid == CLOCK_REALTIME) {
+			struct timespec real_time_ts;
+			if (clock_gettime(CLOCK_REALTIME, &real_time_ts) == -1) {
+				return;
+			}
+			c->last_ts.ns = tmv_to_nanoseconds(timespec_to_tmv(real_time_ts));
+			c->is_ts_available = true;
+			c->is_target = true;
+		}
+
 		if (!c->is_target)
 			continue;
 
@@ -813,7 +823,7 @@ int main(int argc, char *argv[])
 			pr_err("poll failed");
 			break;
 		}
-		if (err > 0) {
+		if (err >= 0) {
 			err = ts2phc_collect_pps_source_tstamp(&priv);
 			if (err) {
 				pr_err("failed to collect PPS source tstamp");


### PR DESCRIPTION
## Problem
The goal is to synchronize the system clock (`CLOCK_REALTIME`) with GNSS/GPS. Typically, this is achieved by using `ts2phc` to sync a hardware clock (PHC) to GPS and then using `phc2sys` to synchronize the system clock with the PHC, as described in [this article](https://www.starlingx.io/blog/starlingx-ptp-multi-instance-features/).

![image](https://github.com/user-attachments/assets/c19d232d-a552-413d-8e13-1ffbe4fb93e0)

However, on my modem, neither a hardware clock nor a PPS device is available. Instead, I directly synchronized the system clock with GPS.

## Solution
- `ts2phc` always attempts to initialize a PPS pin, which is unnecessary when using NMEA sentences. Additionally, `CLOCK_REALTIME` does not support PPS pins. To prevent this, we need to return early in `ts2phc_pps_sink.c` (line 191) before checking the number of PHC pins.
- Since there is no PHC, the system clock's timestamp must be manually set. This is handled by retrieving the time in `ts2phc.c` (line 483).
- Another key change is in `ts2phc.c` (line 826), where an equal sign (`=`) was added. This is necessary because, when using NMEA, there is no PPS signal, but clock synchronization is still required.

## Testing
The changes were tested on a real device with GNSS/GPS, and synchronization worked as expected.
To manually test, you can create a pipe (e.g., `/tmp/nmea_pipe`) and send NMEA-like sentences into it (only RMC sentences are required). Then, run `ts2phc` with the serial port set to the previously created pipe:
```
./ts2phc -c CLOCK_REALTIME -s nmea -mq -l 7 --ts2phc.nmea_serialport /tmp/nmea_pipe --leapfile ./leap-seconds.list --clock_servo nullf
```