### PR TITLE
ts2phc: PHC sync logic shall not skip step if set_freq fails

### DIFF
--- a/ts2phc.c
+++ b/ts2phc.c
@@ -524,10 +524,8 @@ static void ts2phc_synchronize_clocks(struct ts2phc_private *priv, int autocfg)
 		case SERVO_UNLOCKED:
 			break;
 		case SERVO_JUMP:
-			if (clockadj_set_freq(c->clkid, -adj)) {
-				goto servo_unlock;
-			}
-			if (clockadj_step(c->clkid, -offset)) {
+			if (0 != clockadj_set_freq(c->clkid, -adj) &&
+			    0 != clockadj_step(c->clkid, -offset)) {
 				goto servo_unlock;
 			}
 			break;


### PR DESCRIPTION
Some clocks do not support adjustment by frequency but support by step. Current implementation does not try to apply step after frequency adjustment fails. This commit fixes the logic to try both before goto error handling.